### PR TITLE
Exclude temp ssh config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Host moserver3 #Third server
 HostName localhost
 </pre>
 Script greps data from multiple config files via pattername <i>'config*'</i> in <i>~/.ssh</i> dir.<br>
+(excludes temp files where the filename ends with a '~')<br>
 So you can split config to multiple files and use them with <i>Include</i> directive, example:
 <pre>
 Include config_moscow

--- a/sshto
+++ b/sshto
@@ -288,7 +288,7 @@ second_dialog () {
 }
 
 #-------------{ Create hosts list. Get hosts and descriptions from ~/.ssh/config. }----------------
-IFSOLD=$IFS; IFS=$'\n'; for host in $(grep -h "Host " ~/.ssh/config* | sed '/\*/d; s/Host //g;'); {
+IFSOLD=$IFS; IFS=$'\n'; for host in $(find . -maxdepth 1 -iname "config*" ! -iname "config*~" | xargs grep -h "Host " | sed '/\*/d; s/Host //g;'); {
 
     name="${host// #*/}" # Get HostName
     desc="${host//*#/}"  # Get Description

--- a/sshto
+++ b/sshto
@@ -288,7 +288,7 @@ second_dialog () {
 }
 
 #-------------{ Create hosts list. Get hosts and descriptions from ~/.ssh/config. }----------------
-IFSOLD=$IFS; IFS=$'\n'; for host in $(find . -maxdepth 1 -iname "config*" ! -iname "config*~" | xargs grep -h "Host " | sed '/\*/d; s/Host //g;'); {
+IFSOLD=$IFS; IFS=$'\n'; for host in $(find ~/.ssh/ -maxdepth 1 -iname "config*" ! -iname "config*~" | xargs grep -h "Host " | sed '/\*/d; s/Host //g;'); {
 
     name="${host// #*/}" # Get HostName
     desc="${host//*#/}"  # Get Description


### PR DESCRIPTION
If there are any temp config files (ending with '~') then these are also included when running sshto, this causes duplicate entries to show in menu.

This updates the grep statement to use 'find' with an exclude for the temp files.  Additional excludes can be easily added if required.