### PR TITLE
Case insensitive hostname

### DIFF
--- a/sshto
+++ b/sshto
@@ -506,7 +506,7 @@ strt && host == "DUMMY"{
     print host, "DUMMY", desc
     strt=0
 }
-strt && /HostName /{
+tolower($strt) ~ /hostname/{
     hostname=$2
     print host, hostname, desc
     strt=0

--- a/sshto-1.0/ChangeLog
+++ b/sshto-1.0/ChangeLog
@@ -1,2 +1,4 @@
 1.0:
 * Initial release.
+1.1:
+* Case insensitive hostname.


### PR DESCRIPTION
Ssh works with case insensitive "hostname", I made the change for this to do the same. I didn't want to rename the 1.0 directory and that will break file history. So I just make the script change. Lemme know how you want to handle it.

I actually made the change to root sshto, and the one inside the 1.0 dir, but only one commited. Strange. Maybe because they are the same name?