### PR TITLE
Dynamically rename the tmux window or screen title

### DIFF
--- a/sshto
+++ b/sshto
@@ -244,7 +244,7 @@ edit_conf(){
 }
 
 #------------------------{ SSH to target server }-----------------------------------------------------------------------
-go_to_target(){ clear; ssh $SSH_OPT $target || pause; }
+go_to_target(){ set_title; clear; ssh $SSH_OPT $target || pause; reset_title; }
 
 #------------------------{ Add aliases }--------------------------------------------------------------------------------
 add_aliases(){
@@ -304,6 +304,27 @@ bye(){
     ls $lsopts
     exit 0
 };  trap bye INT
+
+#------------------------{ tmux/GNU screen renaming function }---------------------------------------------------------
+set_title () {
+    if type tmux >/dev/null 2>/dev/null; then
+        WINDOWNAME=$(tmux display-message -p '#W') # Get current window title
+        tmux rename-window "$target"
+    fi
+    if type screen >/dev/null 2>/dev/null; then
+        WINDOWNAME=${SHELL##*/} # Get SHELL name (e.g. bash) as window title not possible
+        printf $'\ek%s\e\\' "$target"
+    fi
+}
+
+reset_title () {
+    if type tmux >/dev/null 2>/dev/null; then
+        tmux rename-window "$WINDOWNAME"
+    fi
+    if type screen >/dev/null 2>/dev/null; then
+        printf $'\ek%s\e\\' "$WINDOWNAME"
+    fi
+}
 
 #============================>-{ Dialog functions }-<===================================================================
 do='--output-fd 1 --colors' # dialog common options


### PR DESCRIPTION
Added new methods to rename the tmux window or screen title to match the Host being connected to.  This will also revert on disconnect to prior title.  Added methods to go_to_target method.

I've used this function for a couple of years, thought others might like it.