### PR TITLE
make it work with other bash locations than /bin/bash

### DIFF
--- a/sshto
+++ b/sshto
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #--------------------------{ Default values }---------------------------------------------------------------------------
      OPT=$1     # Options.
   sshdir=~/.ssh # Ssh configfiles folder


### PR DESCRIPTION
 (e.g. MacOS with a more recent bash)

_Running script files through /usr/bin/env has the advantage of automatically searching for the default version of the interpreter in the current environment. This way, we don’t need to search for it in a specific location in the system, as the paths may be different in other systems._

[baeldung.com/linux/bash-shebang-lines](https://www.baeldung.com/linux/bash-shebang-lines)